### PR TITLE
delete duplicate eagle3 and ngram tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -56,8 +56,6 @@ l0_b200:
   - unittest/_torch/modeling -k "modeling_mixtral"
   - unittest/_torch/modeling -k "modeling_deepseek"
   - unittest/_torch/auto_deploy/unit/singlegpu
-  - unittest/_torch/speculative/test_eagle3.py
-  - unittest/_torch/speculative/test_ngram.py
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
Both of:
- `unittest/_torch/speculative/test_eagle3.py`
- `unittest/_torch/speculative/test_ngram.py` Are already covered by:
`unittest/_torch -k "not (modeling or multi_gpu or auto_deploy)"`